### PR TITLE
Make codegen respect %foreign name half way

### DIFF
--- a/Sinter.ipkg
+++ b/Sinter.ipkg
@@ -13,17 +13,20 @@ bugtracker = "https://github.com/CodingCellist/idris2-sinter/issues"
 langversion >= 0.5.1
 
 -- packages to add to search path
--- depends =
+depends = idris2
+        , contrib
+        , network
+
 
 -- modules to install
-modules = Sinter, Idris2Sinter
+modules = Sinter, Idris2Sinter, TagList
 
 -- main file (i.e. file to load at REPL)
 main = Idris2Sinter
 
 -- name of executable
 executable = "idris2-sinter"
-opts = "-p idris2 -p contrib -p network"
+-- opts = ""
 sourcedir = "src"
 -- builddir =
 -- outputdir =

--- a/src/HelloWorld.idr
+++ b/src/HelloWorld.idr
@@ -1,2 +1,12 @@
+module Main
+
+%foreign "sinter:prim__puts"
+prim__puts : String -> PrimIO ()
+
+||| Output a string to stdout without a trailing newline.
+export
+putStr : HasIO io => String -> io ()
+putStr str = primIO (prim__puts str)
+
 main : IO ()
-main = putStrLn "Hello sinter world!"
+main = Main.putStr "Hello sinter world!"


### PR DESCRIPTION
Code that reference foreign function still use mangled name

excerpt of generated .sin code
```
[dec;prim__puts;[String1;%World2]]
[def;Main::putStr-0;[arg-2;eta-0];[Main::prim__puts;arg-2;eta-0]]
```
